### PR TITLE
Update getPageData to properly end deferred image loading

### DIFF
--- a/lib/single-file/index.js
+++ b/lib/single-file/index.js
@@ -39,13 +39,20 @@ this.singlefile = this.singlefile || {
 		vendor: {},
 		modules: {},
 		async getPageData(options = {}, initOptions, doc = window.document, win = window) {
+			const frames = this.processors.frameTree.content.frames;
 			this.main.init(initOptions);
 			if (doc && window) {
 				this.helper.initDoc(doc);
 				const preInitializationPromises = [];
 				if (!options.saveRawPage) {
-					if (!options.removeFrames) {
-						preInitializationPromises.push(this.processors.frameTree.content.frames.getAsync(options));
+					if (!options.removeFrames && frames && window.frames && window.frames.length) {
+						let frameTreePromise;
+						if (options.loadDeferredImages) {
+							frameTreePromise = new Promise(resolve => setTimeout(() => resolve(frames.getAsync(options)), options.loadDeferredImagesMaxIdleTime - frames.TIMEOUT_INIT_REQUEST_MESSAGE));
+						} else {
+							frameTreePromise = frames.getAsync(options);
+						}
+						preInitializationPromises.push(frameTreePromise);
 					}
 					if (options.loadDeferredImages) {
 						preInitializationPromises.push(this.processors.lazy.content.loader.process(options));
@@ -57,8 +64,18 @@ this.singlefile = this.singlefile || {
 			options.win = win;
 			options.insertSingleFileComment = true;
 			options.insertCanonicalLink = true;
+			options.onprogress = event => {
+				if (event.type === event.RESOURCES_INITIALIZED) {
+					if (options.loadDeferredImagesKeepZoomLevel) {
+						singlefile.lib.processors.lazy.content.loader.resetZoomLevel();
+					}
+				}
+			};
 			const singleFile = new this.SingleFile(options);
 			await singleFile.run();
+			if (!options.saveRawPage && !options.removeFrames && frames) {
+				frames.cleanup(options);
+			}
 			return await singleFile.getPageData();
 		}
 	}


### PR DESCRIPTION
We use SingleFileZ as an API as described here (https://github.com/gildas-lormeau/SingleFile/wiki/How-to-integrate-the-API-of-SingleFile-into-an-extension)[url], but the `getPageData` function is missing some extra work that gets done in `processPage` (https://github.com/gildas-lormeau/SingleFileZ/blob/master/extension/core/content/content-main.js#L121)[url].

This simply moves over all the code from that function to achieve feature parity. In particular we need to call this function `singlefile.lib.processors.lazy.content.loader.resetZoomLevel();` to reset the zoom level on the document after loading deferred images.