### PR TITLE
Check that document.doctype is not null

### DIFF
--- a/src/single-file/processors/compression/compression-display.js
+++ b/src/single-file/processors/compression/compression-display.js
@@ -40,7 +40,7 @@ async function display(document, docContent, { disableFramePointerEvents } = {})
 		} else {
 			document.insertBefore(doc.doctype, document.documentElement);
 		}
-	} else {
+	} else if (document.doctype) {
 		document.doctype.remove();
 	}
 	if (disableFramePointerEvents) {


### PR DESCRIPTION
I ran into this because I wanted an export of a Google Doc without page breaks. PDF needs page breaks, so I thought SingleFile would be good. The SingleFIleZ extension ran fine without error but the resulting HTML file showed only a blank page with this error:

<img width="957" alt="Screen Shot 2022-04-29 at 6 42 23 PM" src="https://user-images.githubusercontent.com/44614862/166085760-887614db-0a25-4dad-9ac6-ba28c27cb983.png">

The red underline is wrong - it's actually the `.remove()` which throws the error. https://developer.mozilla.org/en-US/docs/Web/API/Document/doctype#notes says it can be null.

I opened the Google Doc HTML export and saw it was missing a doctype:

<img width="682" alt="image" src="https://user-images.githubusercontent.com/44614862/166085746-6c6cb29e-73e7-4238-b472-3dc556f6c16f.png">

Adding `<!DOCTYPE html>` and rerunning SingleFileZ on the patched file fixed it. It'd been good is SingleFileZ could handle these broken HTML files though.

I'm in Firefox 99 so maybe this doesn't happen in Chrome.